### PR TITLE
Allow fractional intervals

### DIFF
--- a/R/S3-methods.R
+++ b/R/S3-methods.R
@@ -962,13 +962,13 @@ get_hdi_data <- function(x, digits, ci_pattern = "hdi.", ci_name = "HDI") {
 
     if (ci_pos[i] < 0) {
       if (!is.null(prob))
-        interv <- round(100 * prob[1])
+        interv <- 100 * prob[1]
       else
         interv <- 90
     } else
-      interv <- round(as.numeric(substr(cn[i], ci_pos[i] + 1, nchar(cn[i]))))
+      interv <- as.numeric(substr(cn[i], ci_pos[i] + 1, nchar(cn[i])))
 
-    colnames(tmp) <- sprintf("%s(%d%%)", ci_name, interv)
+    colnames(tmp) <- sprintf("%s(%.9g%%)", ci_name, interv)
     tmp
   }) %>%
     dplyr::bind_cols()


### PR DESCRIPTION
Here is a change that should fix https://github.com/strengejacke/sjstats/issues/77

I removed the round() function calls and replaced %d with %g
```r
> d <- c(99, 99.9, 99.99, 99.999, 99.9999, 99.99999, 99.999999)
```
Old Approach:
```r
> sprintf("%d", round(d))
#> [1] "99"  "100" "100" "100" "100" "100" "100"
```
New Approach:
```r
> sprintf("%.9g", d)
#> [1] "99"        "99.9"      "99.99"     "99.999"    "99.9999"   "99.99999"  "99.999999"
```