### PR TITLE
Filter for complete cases in a way that works with groups

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Depends:
 Imports:
     bayestestR (>= 0.2.2),
     broom,
-    dplyr,
+    dplyr (>= 0.8.1),
     emmeans,
     insight (>= 0.4.0),
     lme4,

--- a/R/helpfunctions.R
+++ b/R/helpfunctions.R
@@ -48,16 +48,10 @@ dot_names <- function(dots) unname(unlist(lapply(dots, as.character)))
 #' @importFrom stats complete.cases
 #' @importFrom rlang .data
 get_grouped_data <- function(x) {
-  # nest data frame
-  grps <- tidyr::nest(x)
-
-  # remove NA category
-  cc <- grps %>%
-    dplyr::select(-.data$data) %>%
-    stats::complete.cases()
-
-  # select only complete cases
-  grps <- grps %>% dplyr::filter(!! cc)
+  # retain observations that are complete wrt grouping vars, then nest
+  grps <- x %>%
+    dplyr::group_modify(~ filter(.x, complete.cases(.y))) %>%
+    nest()
 
   # arrange data
   if (length(dplyr::group_vars(x)) == 1)

--- a/R/helpfunctions.R
+++ b/R/helpfunctions.R
@@ -50,8 +50,8 @@ dot_names <- function(dots) unname(unlist(lapply(dots, as.character)))
 get_grouped_data <- function(x) {
   # retain observations that are complete wrt grouping vars, then nest
   grps <- x %>%
-    dplyr::group_modify(~ filter(.x, complete.cases(.y))) %>%
-    nest()
+    dplyr::group_modify(~ dplyr::filter(.x, stats::complete.cases(.y))) %>%
+    tidyr::nest()
 
   # arrange data
   if (length(dplyr::group_vars(x)) == 1)


### PR DESCRIPTION
Prepare for the fact that `tidyr::nest()` returns a grouped data frame in v1.0.0 and higher. The existing `filter()` call fails.

In our tidyr revdep check, we see problems with examples and tests:

https://github.com/tidyverse/tidyr/blob/master/revdep/problems.md#sjstats